### PR TITLE
Typos and wrong order of commands

### DIFF
--- a/config/binds.lua
+++ b/config/binds.lua
@@ -317,7 +317,7 @@ add_binds("normal", {
         function (w) w:enter_cmd(":tabopen " .. (w.view.uri or "")) end),
 
     key({}, "W",
-        "Open one or more URLs based on current locaton in a new window.",
+        "Open one or more URLs based on current location in a new window.",
         function (w) w:enter_cmd(":winopen " .. (w.view.uri or "")) end),
 
     -- History

--- a/config/binds.lua
+++ b/config/binds.lua
@@ -219,10 +219,10 @@ add_binds("normal", {
     key({}, "Page_Up", "Scroll page up.",
         function (w) w:scroll{ ypagerel = -1.0 } end),
 
-    key({}, "Home", "Go to the end of the document.",
+    key({}, "Home", "Go to the top of the document.",
         function (w) w:scroll{ y =  0 } end),
 
-    key({}, "End", "Go to the top of the document.",
+    key({}, "End", "Go to the end of the document.",
         function (w) w:scroll{ y = -1 } end),
 
     -- Specific scroll


### PR DESCRIPTION
Fix a typo and the wrong documented order of Top and End.