### PR TITLE
Document globals.term used by formfiller

### DIFF
--- a/config/globals.lua
+++ b/config/globals.lua
@@ -13,6 +13,8 @@ globals = {
  -- load_etc_hosts      = false,
  -- Disables checking if a filepath exists in search_open function
  -- check_filepath      = false,
+ -- Specify your preferred terminal emulator
+ -- term                = "urxvt",
 }
 
 -- Make useragent


### PR DESCRIPTION
Mention the globals.term configuration option in the file `globals.lua`.