### PR TITLE
fix default useragent & add test

### DIFF
--- a/config/globals.lua
+++ b/config/globals.lua
@@ -18,7 +18,7 @@ globals = {
 -- Make useragent
 local _, arch = luakit.spawn_sync("uname -sm")
 -- Only use the luakit version if in date format (reduces identifiability)
-local lkv = string.match(luakit.version, "^(%d+.%d+.%d+)")
+local lkv = string.match(luakit.version, "^(%d+%.%d+%.%d+)")
 globals.useragent = string.format("Mozilla/5.0 (%s) AppleWebKit/%s+ (KHTML, like Gecko) WebKitGTK+/%s luakit%s",
     string.sub(arch, 1, -2), luakit.webkit_user_agent_version,
     luakit.webkit_version, (lkv and ("/" .. lkv)) or "")

--- a/tests/test_config_globals.lua
+++ b/tests/test_config_globals.lua
@@ -1,0 +1,29 @@
+package.path = package.path .. ";./config/?.lua;./lib/lousy/?.lua"
+require "lunit"
+require "util"
+require "globals"
+
+module("test_config_globals", lunit.testcase, package.seeall)
+
+
+function test_globals()
+  assert_table(globals)
+end
+
+function test_useragent()
+  local originalversion = luakit.version
+
+  local version_patterns = {}
+  version_patterns["2012.09.13-r1-32-g993d814"] = "luakit/2012%.09%.13$"
+  version_patterns["0d5f4ab"] = "luakit$"
+
+  for v, p in pairs(version_patterns) do
+    luakit.version = v
+    package.loaded.globals = nil
+    require "globals"
+    assert_match(p, globals.useragent)
+  end
+
+  luakit.version = originalversion
+end
+


### PR DESCRIPTION
Fixes unescaped wildcards in stock `globals.lua`, which cause part of Luakit versions like `0d5f4ab` to be improperly appended to the useragent, e.g.:
```
Mozilla/5.0 (Linux x86_64) AppleWebKit/537.6+ (KHTML, like Gecko) WebKitGTK+/1.10.2 luakit/0d5f4
```