### PR TITLE
Ignore hidden elements when showing follow hints

### DIFF
--- a/lib/follow.lua
+++ b/lib/follow.lua
@@ -77,6 +77,11 @@ follow_js = [=[
                    || (left = r.left) > win_w || (right  = r.right)  < 0)
                continue;
 
+			var style = window.getComputedStyle(e);
+
+		    if (style.display === 'none' || style.visibility === 'hidden' )
+				continue;
+
             hints[j++] = { element: e, tag: e.tagName,
                 left: left, top: top,
                 width: right - left, height: bottom - top,


### PR DESCRIPTION
Showing hints for elements which are hidden is confusing.