### PR TITLE
Allow soup URIs that are invalid for HTTP

### DIFF
--- a/common/property.c
+++ b/common/property.c
@@ -102,7 +102,7 @@ luaH_gobject_set(lua_State *L, property_t *p, gint vidx, GObject *object)
         else
             tmp.c = g_strdup_printf("http://%s", tmp.c);
         u = soup_uri_new(tmp.c);
-        gboolean valid = !u || SOUP_URI_VALID_FOR_HTTP(u);
+        gboolean valid = u;
         if (valid) {
             g_object_set(object, p->name, u, NULL);
             g_free(tmp.c);


### PR DESCRIPTION
This fixes #169 and "adds" support for SOCKS proxies by removing the
requirement that a URI property set on a GObject must be valid for HTTP.